### PR TITLE
Fix timeout cancellation logic

### DIFF
--- a/lib/pollers/webpagetest/webPageTestPoller.js
+++ b/lib/pollers/webpagetest/webPageTestPoller.js
@@ -106,8 +106,8 @@ WebPageTestPoller.prototype.timeoutReached = function() {
   this.debug('WebPageTestPoller timeoutReached call');
   WebPageTestPoller.super_.prototype.timeoutReached.call(this);
   var self = this;
-  if (typeof this.timeout !== undefined) {
-    this.wpt.cancelTest(this.testId, function(err,data) {
+  if (typeof this.testId !== 'undefined') {
+    this.wpt.cancelTest(this.testId, function(err, data) {
       self.debug('WebPageTest test started [testId=' + self.testId + ']');
     });
   }


### PR DESCRIPTION
## Summary
- correct the variable checked before cancelling WebPageTest

## Testing
- `npm test` *(fails: `node_modules/.bin/mocha: not found`)*