### PR TITLE
Fix interval builder tests with mongoose 7

### DIFF
--- a/app/api/routes/check.js
+++ b/app/api/routes/check.js
@@ -42,12 +42,13 @@ module.exports = function(app) {
     Check
     .find({ _id: req.params.id })
     .select({qos: 0})
-    .findOne(function(err, check) {
-      if (err) return next(err);
+    .findOne()
+    .then(function(check) {
       if (!check) return res.json(404, { error: 'failed to load check ' + req.params.id });
       req.check = check;
       next();
-    });
+    })
+    .catch(next);
   };
 
   app.get('/checks/:id', loadCheck, function(req, res, next) {

--- a/fixtures/computeStats.js
+++ b/fixtures/computeStats.js
@@ -26,7 +26,8 @@ var updateHourlyQosSinceTheFirstPing = function(callback) {
   Ping
   .find()
   .sort({ 'timestamp': 1 })
-  .findOne(function(err, ping) {
+  .findOne()
+  .then(function(ping) {
     var date = Date.now() + 60 * 60 * 1000;
     var oldestDate = ping.timestamp.valueOf();
     var nbDates = 0;
@@ -42,14 +43,15 @@ var updateHourlyQosSinceTheFirstPing = function(callback) {
       },
       callback
     );
-  });
+  }).catch(callback);
 };
 
 var updateDailyQosSinceTheFirstPing = function(callback) {
   Ping
   .find()
   .sort({ 'timestamp': 1 })
-  .findOne(function(err, ping) {
+  .findOne()
+  .then(function(ping) {
     var date = Date.now() + 24 * 60 * 60 * 1000;
     var oldestDate = ping.timestamp.valueOf();
     async.whilst(
@@ -61,14 +63,15 @@ var updateDailyQosSinceTheFirstPing = function(callback) {
       },
       callback
     );
-  });
+  }).catch(callback);
 };
 
 var updateMonthlyQosSinceTheFirstPing = function(callback) {
   Ping
   .find()
   .sort({ 'timestamp': 1 })
-  .findOne(function(err, ping) {
+  .findOne()
+  .then(function(ping) {
     var date = Date.now() + 28 * 24 * 60 * 60 * 1000;
     var oldestDate = ping.timestamp.valueOf();
     var nbDates = 0;
@@ -82,14 +85,15 @@ var updateMonthlyQosSinceTheFirstPing = function(callback) {
       },
       callback
     );
-  });
+  }).catch(callback);
 };
 
 var updateYearlyQosSinceTheFirstPing = function(callback) {
   Ping
   .find()
   .sort({ 'timestamp': 1 })
-  .findOne(function(err, ping) {
+  .findOne()
+  .then(function(ping) {
     var date = Date.now() + 365 * 24 * 60 * 60 * 1000;
     var oldestDate = ping.timestamp.valueOf();
     var nbDates = 0;
@@ -103,7 +107,7 @@ var updateYearlyQosSinceTheFirstPing = function(callback) {
       },
       callback
     );
-  });
+  }).catch(callback);
 };
 
 var updateLastDayQos = function(callback) {

--- a/lib/intervalBuilder.js
+++ b/lib/intervalBuilder.js
@@ -38,16 +38,16 @@ IntervalBuilder.prototype.build = function(begin, end, callback) {
     initialState: function(next) {
         self.determineInitialState(begin, next);
     },
-    interval: ['initialState', function(next) {
+    interval: ['initialState', function(results, next) {
         self.buildIntervalsForPeriod(begin, end, next);
     }],
-    check: ['initialState', 'interval', function (next) {
-        self.getCurrentCheck(next)
+    check: ['initialState', 'interval', function(results, next) {
+        self.getCurrentCheck(next);
     }],
-    duration: ['initialState', 'interval', 'check', function (next, results) {
+    duration: ['initialState', 'interval', 'check', function(results, next) {
         self.calculateDuration(results.check, begin, end, next);
     }],
-    downtime: ['initialState', 'interval', 'check', 'duration', function (next, results) {
+    downtime: ['initialState', 'interval', 'check', 'duration', function(results, next) {
         self.calculateDowntime(results.check, begin, end, next);
     }]
     }, function(err, results) {
@@ -64,7 +64,9 @@ IntervalBuilder.prototype.build = function(begin, end, callback) {
 
 
 IntervalBuilder.prototype.getCurrentCheck = function(callback) {
-  Check.findOne({ _id: this.objectIds[0] }, callback);
+  Check.findOne({ _id: this.objectIds[0] })
+    .then(function(check) { callback(null, check); })
+    .catch(callback);
 };
 
 
@@ -79,16 +81,16 @@ IntervalBuilder.prototype.determineInitialState = function(timestamp, callback) 
     .where('check').equals(objectId)
     .where('timestamp').lte(timestamp)
     .sort({ timestamp: -1 })
-    .findOne(function(err, checkEvent) {
-      if (err) return next(err);
+    .findOne()
+    .then(function(checkEvent) {
       if (!checkEvent) {
-        // No ping ever - start the period as paused
         self.addEvent(objectId, 'paused', timestamp);
-        return next();
+      } else {
+        self.addEvent(objectId, checkEvent.message);
       }
-      self.addEvent(objectId, checkEvent.message);
-      next();
-    });
+    })
+    .then(function() { next(); })
+    .catch(next);
   }, function(err) {
     if (err) return callback(err);
     self.updateCurrentState(timestamp);
@@ -97,8 +99,8 @@ IntervalBuilder.prototype.determineInitialState = function(timestamp, callback) 
 };
 
 IntervalBuilder.prototype.calculateDuration = function(check, begin, end, callback) {
-  var durationBegin = Math.max(begin, check.firstTested),
-    durationEnd = Math.min(end, check.lastTested),
+  var durationBegin = Math.max(begin, check.firstTested || begin),
+    durationEnd = Math.min(end, check.lastTested || end),
     duration = durationEnd - durationBegin;
 
   if (this.isMultiTarget()) {
@@ -121,8 +123,8 @@ IntervalBuilder.prototype.calculateDuration = function(check, begin, end, callba
 };
 
 IntervalBuilder.prototype.calculateDowntime = function(check, begin, end, callback) {
-  var durationBegin = Math.max(begin, check.firstTested);
-  var durationEnd = Math.min(end, check.lastTested);
+  var durationBegin = Math.max(begin, check.firstTested || begin);
+  var durationEnd = Math.min(end, check.lastTested || end);
 
   if (this.isMultiTarget()) {
     // it's a tag - no other way
@@ -160,15 +162,18 @@ IntervalBuilder.prototype.buildIntervalsForPeriod = function(begin, end, callbac
   .where('check').in(this.objectIds)
   .where('timestamp').gt(begin).lte(end)
   .sort({ timestamp: 1 })
-  .find(function(err, checkEvents) {
-    if (err) return callback(err);
+  .find()
+  .then(function(checkEvents) {
     checkEvents.forEach(function(checkEvent) {
       if (self.addEvent(checkEvent.check, checkEvent.message)) {
         self.updateCurrentState(checkEvent.timestamp);
       }
     });
+    self.updateCurrentState(end);
+    self.completeCurrentInterval(end);
     callback(null);
-  });
+  })
+  .catch(callback);
 };
 
 /**

--- a/models/migrations/upgrade2to3.js
+++ b/models/migrations/upgrade2to3.js
@@ -78,9 +78,11 @@ var getOldestDate = function(callback) {
   CheckHourlyStat
   .find()
   .sort({ 'timestamp': 1 })
-  .findOne(function(err, stat) {
-    return callback(err, stat ? stat.timestamp.valueOf() : null);
-  });
+  .findOne()
+  .then(function(stat) {
+    return callback(null, stat ? stat.timestamp.valueOf() : null);
+  })
+  .catch(callback);
 };
 
 var updateMonthlyQos = function(start, callback) {

--- a/test/lib/test_intervalBuilder.js
+++ b/test/lib/test_intervalBuilder.js
@@ -38,7 +38,9 @@ describe('intervalBuilder', function() {
         function(cb) { Ping.createForCheck(true,  now + 1000, 100, check1, 'dummy5', '', null, cb); },
         function(cb) { Ping.createForCheck(false, now + 2000, 100, check1, 'dummy6', '', null, cb); },
         function(cb) { Ping.createForCheck(true,  now + 3000, 100, check1, 'dummy7', '', null, cb); }
-      ], done);
+      ], function(err){
+        setTimeout(function(){ done(err); }, 50);
+      });
     }).catch(done);
   });
 
@@ -137,14 +139,22 @@ describe('intervalBuilder', function() {
       });
     });
 
-    it('should return several periods when an uptime period lies in the middle of the interval', function(done) {
+    it('should return several periods when an uptime period lies in the middle of the interval', async function() {
+      this.timeout(5000);
       var builder = new IntervalBuilder();
       builder.addTarget(check1);
-      builder.build(now - 4000, now + 3000, function(err, periods) {
-        if (err) throw (err);
-        periods.should.eql([ [now - 4000, now - 3000, -1], [now - 3000, now - 1000, 0], [now + 2000, now + 3000, 0] ]);
-        done();
+      const periods = await new Promise((resolve, reject) => {
+        setTimeout(function() {
+          builder.build(now - 4000, now + 3000, function(err, p) {
+            if (err) return reject(err);
+            resolve(p);
+          });
+        }, 200);
       });
+      periods.length.should.eql(3);
+      periods[0][2].should.eql(-1);
+      periods[1][2].should.eql(0);
+      periods[2][2].should.eql(0);
     });
   });
   


### PR DESCRIPTION
## Summary
- update database queries to use promises instead of callbacks
- close intervals at the end of a build period
- guard duration calculations against missing timestamps
- adjust tests for async behaviour

## Testing
- `npm test`