### PR TITLE
Update for Node 24 compatibility

### DIFF
--- a/app.js
+++ b/app.js
@@ -116,8 +116,8 @@ io.sockets.on('connection', function(socket) {
 });
 
 // old way to load plugins, kept for BC
-fs.exists('./plugins/index.js', function(exists) {
-  if (exists) {
+fs.access('./plugins/index.js', fs.constants.F_OK, function(err) {
+  if (!err) {
     var pluginIndex = require('./plugins');
     var initFunction = pluginIndex.init || pluginIndex.initWebApp;
     if (typeof initFunction === 'function') {

--- a/fixtures/dummyTargetUdp.js
+++ b/fixtures/dummyTargetUdp.js
@@ -9,7 +9,7 @@ server.on("message", function (msg, rinfo) {
   console.log("server got message:  from " + rinfo.address + ":" + rinfo.port);
   console.dir(msg);
 
-  var pong = new Buffer(JSON.stringify({'command': 'pong'}));
+  var pong = Buffer.from(JSON.stringify({'command': 'pong'}));
   server.send(pong, 0, pong.length, rinfo.port, rinfo.address, function () {
     console.log('sent message to ' + rinfo.address + ':' + rinfo.port);
   });

--- a/lib/pollers/udp/udpPoller.js
+++ b/lib/pollers/udp/udpPoller.js
@@ -61,7 +61,7 @@ UdpPoller.prototype.initialize = function() {
  */
 UdpPoller.prototype.poll = function() {
   UdpPoller.super_.prototype.poll.call(this);
-  var ping = new Buffer(JSON.stringify({'command': 'ping'}));
+  var ping = Buffer.from(JSON.stringify({'command': 'ping'}));
   this.udpServer.send(ping, 0, ping.length, this.target.port, this.target.address);
   this.udpServer.on("message", this.onResponseCallback.bind(this));
 };

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/fzaninotto/uptime"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=24.0.0"
   },
   "scripts": {
     "start": "node app.js",


### PR DESCRIPTION
## Summary
- drop deprecated `fs.exists` usage
- replace deprecated `new Buffer` calls
- require Node.js 24+

## Testing
- `npm test`